### PR TITLE
Switch var compressed to "true"

### DIFF
--- a/js/armory.js
+++ b/js/armory.js
@@ -7,7 +7,7 @@
 	var PUBLIC_KEY_VERSION;// = 0x47;
 	var PRIVATE_KEY_VERSION;// = 0x80;
 	var ADDRESS_URL_PREFIX;// = 'https://explorer.vertcoin.org/'
-	var compressed;// = false;	//default
+	var compressed = true;// = false;	//default
 
 function armory_extend_chain(pubKey, chainCode, privKey, fromPrivKey
 ,PUBLIC_KEY_VERSION, PRIVATE_KEY_VERSION, ADDRESS_URL_PREFIX, compressed) {

--- a/js/electrum.js
+++ b/js/electrum.js
@@ -5,7 +5,7 @@
 PUBLIC_KEY_VERSION;
 PRIVATE_KEY_VERSION;
 ADDRESS_URL_PREFIX;
-compressed;
+compressed = true;
 
 function electrum_extend_chain(pubKey, privKey, n, forChange, fromPrivKey
 , PUBLIC_KEY_VERSION, PRIVATE_KEY_VERSION, ADDRESS_URL_PREFIX, compressed) {


### PR DESCRIPTION
Switch var compressed to "true", because GaleonCoin using compressed privkey and addresses:
https://www.ntirawen.com/2019/03/bitcoin-compressed-and-uncompressed.html